### PR TITLE
feat: add domain template library (6 pre-built sphere templates)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { loadData, saveData, generateId, exportData, validateImportData, getDemoData } from './utils/storage';
 import Sphere from './components/Sphere';
 import AddSphereForm from './components/AddSphereForm';
+import TemplateLibrary from './components/TemplateLibrary';
 import Onboarding from './components/Onboarding';
 import './App.css';
 
@@ -63,6 +64,32 @@ function App() {
           order: 2,
         },
       ],
+    };
+    setData((prev) => ({
+      ...prev,
+      spheres: [...prev.spheres, newSphere],
+    }));
+  }
+
+  /**
+   * Creates a sphere from a template definition.
+   * First step (order 0) is auto-completed (endowed progress).
+   * All steps get unique IDs and proper structure.
+   */
+  function handleAddFromTemplate(template) {
+    const newSphere = {
+      id: generateId(),
+      name: template.name,
+      level: 1,
+      steps: template.steps.map((step) => ({
+        id: generateId(),
+        title: step.title,
+        description: '',
+        type: step.type,
+        milestone: step.milestone || null,
+        completed: step.order === 0,
+        order: step.order,
+      })),
     };
     setData((prev) => ({
       ...prev,
@@ -154,6 +181,7 @@ function App() {
 
       <div className="app__footer">
         <AddSphereForm onAdd={handleAddSphere} />
+        <TemplateLibrary onSelectTemplate={handleAddFromTemplate} />
 
         <div className="app__data-section">
           <span className="app__data-label">Дані</span>

--- a/src/components/TemplateLibrary.css
+++ b/src/components/TemplateLibrary.css
@@ -1,0 +1,110 @@
+/* ========================================================================
+   TemplateLibrary -- Grid of domain template cards
+   ======================================================================== */
+
+.template-library {
+  margin-top: 16px;
+}
+
+.template-library__divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.template-library__divider::before,
+.template-library__divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: #2a2a4a;
+}
+
+.template-library__divider-text {
+  color: #6b7280;
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+/* --- Card grid --- */
+
+.template-library__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+/* --- Individual card --- */
+
+.template-card {
+  background: #1a1a2e;
+  border: 1px solid #2a2a4a;
+  border-radius: 12px;
+  padding: 14px;
+  cursor: pointer;
+  transition: border-color 0.2s, transform 0.15s, box-shadow 0.2s;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: left;
+  font-family: inherit;
+}
+
+.template-card:hover {
+  border-color: #6366f1;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.15);
+}
+
+.template-card:active {
+  transform: translateY(0);
+}
+
+.template-card__icon {
+  font-size: 24px;
+  line-height: 1;
+}
+
+.template-card__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #e5e7eb;
+  margin: 0;
+}
+
+.template-card__desc {
+  font-size: 11px;
+  color: #6b7280;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.template-card__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: auto;
+  padding-top: 6px;
+}
+
+.template-card__step-count {
+  font-size: 11px;
+  color: #4b5563;
+  font-weight: 500;
+}
+
+.template-card__add-label {
+  font-size: 11px;
+  color: #818cf8;
+  font-weight: 600;
+}
+
+/* --- Responsive --- */
+
+@media (max-width: 400px) {
+  .template-library__grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/TemplateLibrary.jsx
+++ b/src/components/TemplateLibrary.jsx
@@ -1,0 +1,65 @@
+import { TEMPLATES } from '../data/templates';
+import './TemplateLibrary.css';
+
+/**
+ * Renders a single template card.
+ * On click, calls onSelect with the template object.
+ */
+function TemplateCard({ template, onSelect }) {
+  return (
+    <button
+      className="template-card"
+      onClick={() => onSelect(template)}
+      type="button"
+      aria-label={`Створити сферу з шаблону "${template.name}"`}
+    >
+      <span className="template-card__icon">{template.icon}</span>
+      <p className="template-card__name">{template.name}</p>
+      <p className="template-card__desc">{template.description}</p>
+      <div className="template-card__meta">
+        <span className="template-card__step-count">
+          {template.steps.length} {getStepWord(template.steps.length)}
+        </span>
+        <span className="template-card__add-label">Додати</span>
+      </div>
+    </button>
+  );
+}
+
+/**
+ * Returns the correct Ukrainian word form for "steps" based on count.
+ * 1 -> "крок", 2-4 -> "кроки", 5+ -> "кроків"
+ */
+function getStepWord(count) {
+  if (count === 1) return 'крок';
+  if (count >= 2 && count <= 4) return 'кроки';
+  return 'кроків';
+}
+
+/**
+ * TemplateLibrary -- Displays a grid of domain template cards.
+ *
+ * Props:
+ *   onSelectTemplate(template) -- called when the user clicks a template card.
+ */
+export default function TemplateLibrary({ onSelectTemplate }) {
+  return (
+    <div className="template-library">
+      <div className="template-library__divider">
+        <span className="template-library__divider-text">
+          Або обери шаблон
+        </span>
+      </div>
+
+      <div className="template-library__grid">
+        {TEMPLATES.map((template) => (
+          <TemplateCard
+            key={template.id}
+            template={template}
+            onSelect={onSelectTemplate}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/data/templates.js
+++ b/src/data/templates.js
@@ -1,0 +1,95 @@
+/**
+ * Domain Template Library -- Pre-built sphere templates for quick start.
+ *
+ * Each template defines a realistic step progression in Ukrainian.
+ * The first step (order: 0) is always type 'current' and will be auto-completed
+ * when the user creates a sphere from the template (endowed progress).
+ *
+ * Step types: 'current', 'free', 'milestone', 'locked'
+ */
+
+export const TEMPLATES = [
+  {
+    id: 'sleep',
+    name: 'Сон',
+    icon: '\ud83c\udf19',
+    description: 'Покращення якості сну крок за кроком',
+    steps: [
+      { title: 'Просто лягаю спати без режиму', type: 'current', order: 0 },
+      { title: 'Встановити будильник на однаковий час', type: 'free', order: 1 },
+      { title: 'Блокування телефону після 22:00', type: 'free', order: 2 },
+      { title: 'Купити маску для сну', type: 'milestone', milestone: "Бюджет на здоров'я", order: 3 },
+      { title: 'Спробувати мелатонін тиждень', type: 'free', order: 4 },
+      { title: 'Стабільний режим 23:00-07:00', type: 'free', order: 5 },
+    ],
+  },
+  {
+    id: 'morning-routine',
+    name: 'Ранковий ритуал',
+    icon: '\u2600\ufe0f',
+    description: 'Побудова продуктивного ранку',
+    steps: [
+      { title: 'Прокидаюсь і одразу в телефон', type: 'current', order: 0 },
+      { title: 'Склянка води одразу після підйому', type: 'free', order: 1 },
+      { title: '5 хвилин розтяжки', type: 'free', order: 2 },
+      { title: 'Сніданок без телефону', type: 'free', order: 3 },
+      { title: 'Планування 3 справ на день', type: 'free', order: 4 },
+      { title: 'Повний ранковий ритуал 30 хвилин', type: 'free', order: 5 },
+    ],
+  },
+  {
+    id: 'fitness',
+    name: 'Фітнес для початківців',
+    icon: '\ud83c\udfcb\ufe0f',
+    description: 'Від дивану до регулярних тренувань',
+    steps: [
+      { title: 'Не займаюсь спортом', type: 'current', order: 0 },
+      { title: '15 хвилин прогулянки щодня', type: 'free', order: 1 },
+      { title: 'Зарядка вранці -- 10 хвилин', type: 'free', order: 2 },
+      { title: 'Купити спортивний килимок', type: 'milestone', milestone: 'Перша покупка', order: 3 },
+      { title: 'YouTube тренування 20 хвилин 3 рази на тиждень', type: 'free', order: 4 },
+      { title: 'Пробне заняття в залі', type: 'milestone', milestone: 'Абонемент', order: 5 },
+      { title: 'Регулярні тренування 3 рази на тиждень', type: 'free', order: 6 },
+    ],
+  },
+  {
+    id: 'finance',
+    name: 'Фінансова база',
+    icon: '\ud83d\udcb0',
+    description: 'Контроль над грошима з нуля',
+    steps: [
+      { title: 'Не веду бюджет', type: 'current', order: 0 },
+      { title: 'Записати витрати за тиждень', type: 'free', order: 1 },
+      { title: 'Встановити додаток для бюджету', type: 'free', order: 2 },
+      { title: 'Створити фонд на екстрені витрати', type: 'milestone', milestone: 'Перша 1000 грн', order: 3 },
+      { title: 'Автоматичне відкладання 10% з доходу', type: 'free', order: 4 },
+      { title: 'Місяць без імпульсивних покупок', type: 'free', order: 5 },
+    ],
+  },
+  {
+    id: 'reading',
+    name: 'Звичка читати',
+    icon: '\ud83d\udcda',
+    description: 'Від нуля до регулярного читання',
+    steps: [
+      { title: 'Не читаю книжок', type: 'current', order: 0 },
+      { title: 'Читати 5 сторінок перед сном', type: 'free', order: 1 },
+      { title: 'Завести список книжок для читання', type: 'free', order: 2 },
+      { title: 'Прочитати першу книгу повністю', type: 'milestone', milestone: 'Перша книга', order: 3 },
+      { title: 'Читати 20 хвилин щодня', type: 'free', order: 4 },
+    ],
+  },
+  {
+    id: 'social',
+    name: 'Соціальні навички',
+    icon: '\ud83e\uddd1\u200d\ud83e\udd1d\u200d\ud83e\uddd1',
+    description: "Розвиток спілкування та зв'язків",
+    steps: [
+      { title: 'Рідко спілкуюсь з людьми', type: 'current', order: 0 },
+      { title: 'Написати одному старому другу', type: 'free', order: 1 },
+      { title: 'Сходити на одну подію або зустріч', type: 'free', order: 2 },
+      { title: 'Запросити когось на каву', type: 'free', order: 3 },
+      { title: 'Регулярні зустрічі раз на тиждень', type: 'free', order: 4 },
+    ],
+  },
+];


### PR DESCRIPTION
## Summary
- Add 6 pre-built Ukrainian sphere templates (Sleep, Morning Routine, Fitness, Finance, Reading, Social Skills) with 5-7 realistic steps each
- New `TemplateLibrary` component renders a 2-column card grid below AddSphereForm with "Або обери шаблон" divider
- Clicking a template card instantly creates a fully populated sphere with first step auto-completed (endowed progress)
- Fog-of-war engine applies automatically to template-created spheres

## Files
- **`src/data/templates.js`** (new) -- 6 template definitions with step progressions
- **`src/components/TemplateLibrary.jsx`** (new) -- grid UI with TemplateCard sub-component
- **`src/components/TemplateLibrary.css`** (new) -- dark theme card grid styles
- **`src/App.jsx`** (modified) -- `handleAddFromTemplate()` + TemplateLibrary integration

## Test plan
- [ ] Template cards render in 2-column grid below "Нова сфера" button
- [ ] Each card shows icon, name, description, step count, "Додати" label
- [ ] Clicking a card creates a new sphere with all template steps
- [ ] First step (order 0) is auto-completed (endowed progress)
- [ ] Fog-of-war applies correctly (only first 2-3 incomplete steps visible)
- [ ] Multiple templates can be added without conflicts
- [ ] Ukrainian text displays correctly across all templates
- [ ] Responsive: single column on screens < 400px

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)